### PR TITLE
Update footer to non-archived repo.

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -76,7 +76,7 @@ class Footer extends React.Component {
           <div>
             <h5>More</h5>
             <a href={`${this.props.config.baseUrl}blog`}>Status</a>
-            <a href="https://github.com/apache/incubator-milagro-crypto">GitHub</a>
+            <a href="https://github.com/apache/incubator-milagro-crypto-c">GitHub</a>
             <a
               className="github-button"
               href={this.props.config.repoUrl}


### PR DESCRIPTION
The github link on the website points to a repo that's marked `Archived`.

Should it point to `milagro-crypto-c`, since that appears to be actively-maintained?